### PR TITLE
⚡ Bolt: [performance improvement] Optimize team matching solo groups filtering using Set

### DIFF
--- a/components/admin/team-matching/matchTeams.ts
+++ b/components/admin/team-matching/matchTeams.ts
@@ -50,7 +50,7 @@ export function matchTeams(users: SimUser[]): Team[] {
   if (users.length === 0) return [];
 
   const prefSet = new Set(
-    users.flatMap((u) => u.preferences.map((p) => `${u.id}:${p}`))
+    users.flatMap((u) => u.preferences.map((p) => `${u.id}:${p}`)),
   );
   const isMutual = (a: string, b: string) =>
     prefSet.has(`${a}:${b}`) && prefSet.has(`${b}:${a}`);
@@ -112,7 +112,8 @@ export function matchTeams(users: SimUser[]): Team[] {
       if (group.length >= 5) return;
       const score =
         group.filter((mid) => user.preferences.includes(mid)).length +
-        group.filter((mid) => userById[mid].preferences.includes(userId)).length;
+        group.filter((mid) => userById[mid].preferences.includes(userId))
+          .length;
       if (
         score > bestScore ||
         (score === bestScore &&
@@ -130,9 +131,10 @@ export function matchTeams(users: SimUser[]): Team[] {
   });
 
   // Step 6: Handle remaining solos
+  const placedSet = new Set(placed);
   const remaining = soloGroups
     .map(([id]) => id)
-    .filter((id) => !placed.includes(id));
+    .filter((id) => !placedSet.has(id));
 
   if (remaining.length >= 3) {
     // Form their own group(s), never exceeding 5, never leaving a group of 1-2


### PR DESCRIPTION
💡 What: Replaced `!placed.includes(id)` with a pre-computed `placedSet.has(id)` lookup inside the filtering loop for solo groups.

🎯 Why: Calling `.includes()` on an array inside a `.filter()` loop results in O(N^2) time complexity. Using a Set provides O(1) lookups, changing the complexity to O(N).

📊 Impact: Significantly improves performance when matching larger numbers of solo students into teams, preventing blocking operations during matching events.

🔬 Measurement: Verified the optimization preserves the exact existing behavior by successfully running the unit test suite `pnpm jest components/admin/team-matching/matchTeams.test.ts`.

---
*PR created automatically by Jules for task [16182564461271880489](https://jules.google.com/task/16182564461271880489) started by @xb1g*