### PR TITLE
feat(projectseed): admin roster tab, DM reminders on by default

### DIFF
--- a/app/projectseed/hub/admin/page.tsx
+++ b/app/projectseed/hub/admin/page.tsx
@@ -1,0 +1,19 @@
+import { redirect } from "next/navigation";
+
+import { loadAdminRoster } from "@/lib/projectseed/admin";
+import { AdminRoster } from "@/components/projectseed/AdminRoster";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminPage() {
+  const load = await loadAdminRoster();
+
+  // A non-admin is sent to the hub rather than shown a "forbidden" page: the
+  // tab is not in their nav, so arriving here is a typed URL or a shared link,
+  // and neither deserves confirmation that the page exists.
+  if (load.state !== "ready") {
+    redirect("/projectseed/hub");
+  }
+
+  return <AdminRoster cohortName={load.cohortName} rows={load.rows} />;
+}

--- a/app/projectseed/hub/layout.tsx
+++ b/app/projectseed/hub/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { DawnAtmosphere } from "@/components/projectseed/DawnAtmosphere";
 import { HubNav } from "@/components/projectseed/HubNav";
+import { isProjectSeedAdmin } from "@/lib/projectseed/admin";
 
 export const metadata: Metadata = {
   title: "ProjectSeed Hub",
@@ -9,7 +10,13 @@ export const metadata: Metadata = {
     "เลือกโปรเจกต์ อธิบายมัน และบอกว่าคุณเข้าห้องเสียงได้เวลาไหน — ห้องของ ProjectSeed",
 };
 
-export default function HubLayout({ children }: { children: React.ReactNode }) {
+export default async function HubLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const isAdmin = await isProjectSeedAdmin();
+
   return (
     <div className="dawn-theme relative min-h-screen overflow-hidden">
       <DawnAtmosphere />
@@ -18,7 +25,7 @@ export default function HubLayout({ children }: { children: React.ReactNode }) {
         <header className="ps-hub-header">
           <p className="dawn-eyebrow">ProjectSeed</p>
           <hr className="dawn-rule ps-hub-header__rule" />
-          <HubNav />
+          <HubNav isAdmin={isAdmin} />
         </header>
 
         <main className="mt-8 flex flex-col gap-10">{children}</main>

--- a/components/projectseed/AdminRoster.tsx
+++ b/components/projectseed/AdminRoster.tsx
@@ -1,0 +1,204 @@
+import type { PseedAdminRosterRow } from "@/lib/projectseed/admin";
+import { summarizeRoster } from "@/lib/projectseed/admin";
+
+interface AdminRosterProps {
+  cohortName: string;
+  rows: PseedAdminRosterRow[];
+}
+
+/**
+ * The delivery view.
+ *
+ * Deliberately not a prettier version of the participant profile: the question
+ * a batch runner asks is "who is stuck", and the answer is always a comparison
+ * across people. So it is a table, and the columns that flag trouble — nobody
+ * linked, no project, hours nobody shares — are styled to be findable by
+ * scanning rather than by reading.
+ */
+export function AdminRoster({ cohortName, rows }: AdminRosterProps) {
+  const totals = summarizeRoster(rows);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <header className="flex flex-col gap-2 border-b border-white/10 pb-6">
+        <p className="text-[11px] font-bold uppercase tracking-[0.2em] text-amber-300">
+          แอดมิน
+        </p>
+        <h1 className="text-3xl font-black tracking-tight text-white">
+          {cohortName}
+        </h1>
+        <p className="text-sm text-slate-400">
+          {totals.participants} คนในรุ่นนี้
+        </p>
+      </header>
+
+      <section className="grid grid-cols-2 gap-y-6 rounded-2xl bg-slate-950/50 p-5 ring-1 ring-white/8 sm:grid-cols-4 sm:divide-x sm:divide-white/8">
+        <Tally label="เชื่อม Discord" value={totals.linked} of={totals.participants} />
+        <Tally label="มีโปรเจกต์" value={totals.withProject} of={totals.participants} />
+        <Tally label="ส่งคำอธิบาย" value={totals.submitted} of={totals.participants} />
+        <Tally label="เลือกเวลาแล้ว" value={totals.scheduled} of={totals.participants} />
+      </section>
+
+      {totals.alwaysAlone > 0 ? (
+        <p className="rounded-xl bg-rose-500/10 px-4 py-3 text-sm text-rose-200 ring-1 ring-rose-400/30">
+          {totals.alwaysAlone} คนเลือกเวลาไว้แต่ไม่มีชั่วโมงไหนที่ทับกับใครเลย —
+          คนกลุ่มนี้จะนั่งทำคนเดียวจนกว่าจะมีคนย้ายมาทับ
+        </p>
+      ) : null}
+
+      {rows.length === 0 ? (
+        <p className="text-sm text-slate-400">ยังไม่มีใครเข้าร่วม</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[820px] border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-white/10 text-left">
+                <Th>ชื่อ</Th>
+                <Th>Discord</Th>
+                <Th>โปรเจกต์</Th>
+                <Th align="right">จอง</Th>
+                <Th align="right">ทับกับคนอื่น</Th>
+                <Th align="right">ชั่วโมงจริง</Th>
+                <Th align="right">ตรงตามจอง</Th>
+                <Th>แจ้งเตือน</Th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <RosterRow key={row.participant_id} row={row} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="text-xs leading-relaxed text-slate-500">
+        “ชั่วโมงจริง” และ “ตรงตามจอง” มาจากบอทดิสคอร์ด — ถ้าบอทยังไม่รัน ทั้งสองคอลัมน์จะเป็น 0
+        ซึ่งเป็นศูนย์จริง ไม่ใช่ค่าที่ยังไม่ได้โหลด
+      </p>
+    </div>
+  );
+}
+
+function Tally({
+  label,
+  value,
+  of,
+}: {
+  label: string;
+  value: number;
+  of: number;
+}) {
+  const complete = of > 0 && value === of;
+
+  return (
+    <div className="flex flex-col gap-1.5 px-1 sm:px-5">
+      <span className="text-[10px] font-bold uppercase tracking-[0.14em] text-slate-500">
+        {label}
+      </span>
+      <span
+        className={`text-4xl font-black leading-none tabular-nums ${
+          complete ? "text-emerald-300" : "text-white"
+        }`}
+      >
+        {value}
+        <span className="text-base font-bold text-slate-600">/{of}</span>
+      </span>
+    </div>
+  );
+}
+
+function Th({
+  children,
+  align = "left",
+}: {
+  children: React.ReactNode;
+  align?: "left" | "right";
+}) {
+  return (
+    <th
+      scope="col"
+      className={`whitespace-nowrap px-3 py-2 text-[10px] font-bold uppercase tracking-[0.12em] text-slate-500 ${
+        align === "right" ? "text-right" : "text-left"
+      }`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function RosterRow({ row }: { row: PseedAdminRosterRow }) {
+  const hours = Math.floor(row.recorded_seconds / 3600);
+  const alone = row.planned_slots > 0 && row.shared_slots === 0;
+
+  return (
+    <tr className="border-b border-white/6 align-top">
+      <td className="px-3 py-3">
+        <span className="font-bold text-white">
+          {row.display_name ?? "ไม่ระบุชื่อ"}
+        </span>
+        <span className="block text-[11px] uppercase tracking-wider text-slate-600">
+          {row.role}
+        </span>
+      </td>
+
+      <td className="px-3 py-3">
+        {row.discord_user_id ? (
+          <span className="font-mono text-xs text-slate-300">
+            @{row.discord_username ?? row.discord_user_id}
+          </span>
+        ) : (
+          <span className="text-xs font-semibold text-amber-300">ยังไม่เชื่อม</span>
+        )}
+      </td>
+
+      <td className="max-w-[16rem] px-3 py-3">
+        {row.project_title ? (
+          <>
+            <span className="text-white">{row.project_title}</span>
+            <span className="block text-[11px] text-slate-500">
+              {row.brief_status === "submitted" ? "ส่งแล้ว" : "ฉบับร่าง"}
+            </span>
+            {row.tags.length > 0 ? (
+              <span className="mt-0.5 block font-mono text-[11px] text-blue-200/70">
+                {row.tags.map((t) => `#${t}`).join(" ")}
+              </span>
+            ) : null}
+          </>
+        ) : (
+          <span className="text-xs font-semibold text-amber-300">ยังไม่เลือก</span>
+        )}
+      </td>
+
+      <td className="px-3 py-3 text-right font-mono tabular-nums text-slate-300">
+        {row.planned_slots}
+      </td>
+
+      <td
+        className={`px-3 py-3 text-right font-mono tabular-nums ${
+          alone ? "font-bold text-rose-300" : "text-slate-300"
+        }`}
+      >
+        {row.shared_slots}
+      </td>
+
+      <td
+        className={`px-3 py-3 text-right font-mono tabular-nums ${
+          hours > 0 ? "text-amber-200" : "text-slate-600"
+        }`}
+      >
+        {hours}
+      </td>
+
+      <td className="px-3 py-3 text-right font-mono tabular-nums text-slate-400">
+        {row.kept_slot_count}
+      </td>
+
+      <td className="whitespace-nowrap px-3 py-3 text-[11px] text-slate-500">
+        {[row.notify_channel ? "ห้อง" : null, row.notify_dm ? "DM" : null]
+          .filter(Boolean)
+          .join(" · ") || "ปิด"}
+      </td>
+    </tr>
+  );
+}

--- a/components/projectseed/HubNav.tsx
+++ b/components/projectseed/HubNav.tsx
@@ -15,6 +15,12 @@ const NAV: NavItem[] = [
   { href: "/projectseed/hub/schedule", label: "เวลา", match: "prefix" },
 ];
 
+const ADMIN_ITEM: NavItem = {
+  href: "/projectseed/hub/admin",
+  label: "แอดมิน",
+  match: "prefix",
+};
+
 function isActive(pathname: string, item: NavItem): boolean {
   if (item.match === "exact") return pathname === item.href;
   return pathname === item.href || pathname.startsWith(`${item.href}/`);
@@ -24,13 +30,14 @@ function isActive(pathname: string, item: NavItem): boolean {
  * ProjectSeed hub section rail — ภาพรวม / โปรเจกต์ / เวลา.
  * Active state is path-driven; styles live under `.ps-hub-nav` in globals.css.
  */
-export function HubNav() {
+export function HubNav({ isAdmin = false }: { isAdmin?: boolean }) {
   const pathname = usePathname();
+  const items = isAdmin ? [...NAV, ADMIN_ITEM] : NAV;
 
   return (
     <nav aria-label="ProjectSeed hub" className="ps-hub-nav">
       <ul className="ps-hub-nav__list">
-        {NAV.map((item, index) => {
+        {items.map((item, index) => {
           const active = isActive(pathname, item);
 
           return (

--- a/components/projectseed/NotificationSettings.tsx
+++ b/components/projectseed/NotificationSettings.tsx
@@ -130,10 +130,6 @@ export function NotificationSettings({ participant }: NotificationSettingsProps)
         </p>
       ) : null}
       {notice ? <p className="text-xs text-emerald-300">{notice}</p> : null}
-
-      <p className="text-xs leading-relaxed text-slate-500">
-        ยังไม่มีบอทคอยส่ง — ตั้งค่าไว้ก่อนได้ แล้วมันจะทำงานทันทีที่บอทออนไลน์
-      </p>
     </section>
   );
 }

--- a/lib/projectseed/admin.ts
+++ b/lib/projectseed/admin.ts
@@ -1,0 +1,106 @@
+import { createClient } from "@/utils/supabase/server";
+import { getActiveCohort } from "@/lib/projectseed/hub";
+
+/**
+ * One row per participant, for the people running the batch.
+ *
+ * `planned_slots` against `kept_slot_count` is the pair worth the whole view:
+ * it is the first measurement of who actually turns up that the programme has
+ * ever had, and the input to PS-207 (mentor-hours per student, open risk 1).
+ */
+export interface PseedAdminRosterRow {
+  participant_id: string;
+  display_name: string | null;
+  role: string;
+  joined_at: string;
+  discord_username: string | null;
+  discord_user_id: string | null;
+  project_title: string | null;
+  tags: string[];
+  brief_status: string | null;
+  planned_slots: number;
+  shared_slots: number;
+  recorded_seconds: number;
+  session_count: number;
+  kept_slot_count: number;
+  last_seen_at: string | null;
+  notify_channel: boolean;
+  notify_dm: boolean;
+}
+
+export async function isProjectSeedAdmin(): Promise<boolean> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return false;
+
+  const { data, error } = await supabase
+    .from("user_roles")
+    .select("role")
+    .eq("user_id", user.id)
+    .in("role", ["admin", "passion-seed-team"])
+    .limit(1);
+
+  if (error) {
+    console.error("[projectseed] admin check failed:", error.message);
+    return false;
+  }
+  return (data?.length ?? 0) > 0;
+}
+
+export type AdminRosterLoad =
+  | { state: "forbidden" }
+  | { state: "no-cohort" }
+  | { state: "ready"; cohortName: string; rows: PseedAdminRosterRow[] };
+
+export async function loadAdminRoster(): Promise<AdminRosterLoad> {
+  // Checked here for the redirect, and again inside the RPC. The database check
+  // is the one that matters — this one only decides what to render.
+  if (!(await isProjectSeedAdmin())) return { state: "forbidden" };
+
+  const cohort = await getActiveCohort();
+  if (!cohort) return { state: "no-cohort" };
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc("pseed_cohort_roster_admin", {
+    p_cohort_id: cohort.id,
+  });
+
+  if (error) {
+    console.error("[projectseed] roster failed:", error.message);
+    return { state: "ready", cohortName: cohort.name, rows: [] };
+  }
+
+  return {
+    state: "ready",
+    cohortName: cohort.name,
+    rows: (data as PseedAdminRosterRow[]) ?? [],
+  };
+}
+
+export interface AdminRosterTotals {
+  participants: number;
+  linked: number;
+  withProject: number;
+  submitted: number;
+  scheduled: number;
+  /** Participants whose declared hours are all solo — nobody to work with. */
+  alwaysAlone: number;
+  recordedHours: number;
+}
+
+export function summarizeRoster(rows: PseedAdminRosterRow[]): AdminRosterTotals {
+  return {
+    participants: rows.length,
+    linked: rows.filter((r) => r.discord_user_id).length,
+    withProject: rows.filter((r) => r.project_title).length,
+    submitted: rows.filter((r) => r.brief_status === "submitted").length,
+    scheduled: rows.filter((r) => r.planned_slots > 0).length,
+    alwaysAlone: rows.filter((r) => r.planned_slots > 0 && r.shared_slots === 0)
+      .length,
+    recordedHours: Math.floor(
+      rows.reduce((sum, r) => sum + r.recorded_seconds, 0) / 3600
+    ),
+  };
+}

--- a/supabase/migrations/20260801030000_projectseed_admin_roster.sql
+++ b/supabase/migrations/20260801030000_projectseed_admin_roster.sql
@@ -1,0 +1,140 @@
+-- ProjectSeed — admin roster, and DM reminders on by default.
+--
+-- Prod-first apply: additive and idempotent.
+
+-- ---------------------------------------------------------------------------
+-- DM reminders default to on.
+--
+-- Safeguarding §3 permits bot DMs under three constraints and does not require
+-- consent, so this is inside policy — but it moves a cost: students now receive
+-- a ProjectSeed DM without having asked for one, which makes the "any account
+-- that chats with you privately is not us" rule something onboarding has to
+-- teach rather than something the opt-in taught by itself. The DM body carries
+-- that line for exactly this reason.
+--
+-- Participants without a linked Discord account are unaffected: pseed_due_reminders
+-- requires a snowflake before wants_dm can be true.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.pseed_participants
+  ALTER COLUMN notify_dm SET DEFAULT true;
+
+UPDATE public.pseed_participants
+SET notify_dm = true
+WHERE notify_dm = false;
+
+-- ---------------------------------------------------------------------------
+-- Who counts as staff.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pseed_is_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_roles r
+    WHERE r.user_id = auth.uid()
+      AND r.role IN ('admin', 'passion-seed-team')
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.pseed_is_admin() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.pseed_is_admin() FROM anon;
+GRANT EXECUTE ON FUNCTION public.pseed_is_admin() TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- The roster.
+--
+-- One row per participant, joining everything the delivery view needs: whether
+-- they linked Discord, what they are building, how many hours they declared,
+-- and how many they actually showed up for. That last pair is the whole point —
+-- it is the first measurement of mentor-hours-per-student the programme has
+-- ever had (strategy doc, open risk 1) and the input to PS-207.
+--
+-- SECURITY DEFINER with the admin check inside, rather than an RLS policy,
+-- because it reads across participants and aggregates voice sessions. A
+-- non-admin gets zero rows, not an error — the page never renders for them.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.pseed_cohort_roster_admin(p_cohort_id uuid)
+RETURNS TABLE (
+  participant_id uuid,
+  display_name text,
+  role text,
+  joined_at timestamptz,
+  discord_username text,
+  discord_user_id text,
+  project_title text,
+  tags text[],
+  brief_status text,
+  planned_slots integer,
+  shared_slots integer,
+  recorded_seconds bigint,
+  session_count integer,
+  kept_slot_count integer,
+  last_seen_at timestamptz,
+  notify_channel boolean,
+  notify_dm boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH slot_totals AS (
+    SELECT a.day_of_week, a.hour_of_day, COUNT(*)::integer AS people
+    FROM public.pseed_availability a
+    JOIN public.pseed_participants p ON p.id = a.participant_id AND p.status = 'active'
+    WHERE a.cohort_id = p_cohort_id
+    GROUP BY a.day_of_week, a.hour_of_day
+  )
+  SELECT
+    p.id,
+    COALESCE(NULLIF(btrim(p.display_name), ''), p.discord_username),
+    p.role,
+    p.created_at,
+    p.discord_username,
+    p.discord_user_id,
+    COALESCE(NULLIF(btrim(pick.custom_title), ''), opt.title),
+    COALESCE(pick.tags, '{}'),
+    pick.status,
+    (SELECT COUNT(*)::integer FROM public.pseed_availability a WHERE a.participant_id = p.id),
+    -- Declared hours that at least two people shipped up for. A participant
+    -- whose every hour is solo is the failure this view exists to surface.
+    (
+      SELECT COUNT(*)::integer
+      FROM public.pseed_availability a
+      JOIN slot_totals t
+        ON t.day_of_week = a.day_of_week AND t.hour_of_day = a.hour_of_day
+      WHERE a.participant_id = p.id AND t.people >= 2
+    ),
+    (SELECT COALESCE(SUM(s.duration_seconds), 0)::bigint FROM public.pseed_voice_sessions s WHERE s.participant_id = p.id),
+    (SELECT COUNT(*)::integer FROM public.pseed_voice_sessions s WHERE s.participant_id = p.id),
+    (
+      SELECT COUNT(DISTINCT a.id)::integer
+      FROM public.pseed_voice_sessions s
+      JOIN public.pseed_availability a
+        ON a.participant_id = p.id
+       AND a.day_of_week = ((EXTRACT(ISODOW FROM (s.joined_at AT TIME ZONE 'Asia/Bangkok'))::int + 6) % 7)
+       AND a.hour_of_day = EXTRACT(HOUR FROM (s.joined_at AT TIME ZONE 'Asia/Bangkok'))::int
+      WHERE s.participant_id = p.id
+    ),
+    (SELECT MAX(s.joined_at) FROM public.pseed_voice_sessions s WHERE s.participant_id = p.id),
+    p.notify_channel,
+    p.notify_dm
+  FROM public.pseed_participants p
+  LEFT JOIN public.pseed_project_picks pick ON pick.participant_id = p.id
+  LEFT JOIN public.pseed_project_options opt ON opt.id = pick.project_option_id
+  WHERE p.cohort_id = p_cohort_id
+    AND p.status = 'active'
+    AND public.pseed_is_admin()
+  ORDER BY p.created_at ASC;
+$$;
+
+REVOKE ALL ON FUNCTION public.pseed_cohort_roster_admin(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.pseed_cohort_roster_admin(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.pseed_cohort_roster_admin(uuid) TO authenticated;


### PR DESCRIPTION
Admin-only roster table on the hub, plus DM reminders defaulting on and the bot-pending note removed from settings.

- `pseed_cohort_roster_admin` is SECURITY DEFINER with the admin check inside — authorization in the database, not in a page guard. Non-admins get zero rows and the route redirects.
- `planned_slots` vs `shared_slots` flags anyone whose declared hours are all solo. `planned` vs `kept` is the PS-207 input.
- `notify_dm` now defaults true and existing rows are backfilled. Inside safeguarding §3, but it means students get a ProjectSeed DM without opting in — onboarding must now teach the impersonation rule explicitly.

Migration applied to production; anon is denied on the new RPC.

Linear: PS-213, PS-214

🤖 Generated with [Claude Code](https://claude.com/claude-code)