### PR TITLE
Add Meta backfill and responsive DM workflow

### DIFF
--- a/app/admin/dm-leads/[id]/page.tsx
+++ b/app/admin/dm-leads/[id]/page.tsx
@@ -1,13 +1,11 @@
 import { notFound } from "next/navigation";
-import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { getConversationWithMessages } from "@/lib/supabase/dm-leads";
 import { DmLeadManageBar } from "@/components/admin/DmLeadManageBar";
-import { DmLeadReplyForm } from "@/components/admin/DmLeadReplyForm";
 import { DmLeadTagsEditor } from "@/components/admin/DmLeadTagsEditor";
 import { LeadNeedsSummary } from "@/components/admin/LeadNeedsSummary";
 import { LeadTagBadges } from "@/components/admin/LeadTagBadges";
-import { DmMessageBubble } from "@/components/admin/DmMessageBubble";
+import { DmLeadConversation } from "@/components/admin/DmLeadConversation";
 
 export const dynamic = "force-dynamic";
 
@@ -48,15 +46,7 @@ export default async function DmLeadDetailPage({
         </div>
       </div>
 
-      <Card>
-        <CardContent className="space-y-3 pt-6">
-          {conversation.dm_messages.map((message) => (
-            <DmMessageBubble key={message.id} message={message} />
-          ))}
-        </CardContent>
-      </Card>
-
-      <DmLeadReplyForm conversation={conversation} />
+      <DmLeadConversation conversation={conversation} />
     </div>
   );
 }

--- a/app/admin/dm-leads/actions.ts
+++ b/app/admin/dm-leads/actions.ts
@@ -25,6 +25,7 @@ export async function replyToLead(conversationId: string, body: string) {
   }
 
   revalidatePath("/admin/dm-leads");
+  revalidatePath(`/admin/dm-leads/${conversationId}`);
   return { ok: true, error: null };
 }
 

--- a/app/api/cron/meta-backfill/route.ts
+++ b/app/api/cron/meta-backfill/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { runDmConversationBackfillBatch, runIgCommentsBackfillBatch } from "@/lib/meta/backfill-runner";
+
+export const maxDuration = 60;
+
+const TIME_BUDGET_MS = 50_000;
+
+function failedBatch(errorCode: string) {
+  return {
+    processed: 0,
+    remaining: -1,
+    stoppedReason: "error" as const,
+    errorCode,
+  };
+}
+
+/**
+ * Stateless catch-up: derives "already done" straight from the DB each tick,
+ * so this can just run every N minutes indefinitely. If Meta's rate limit is
+ * blocking us it stops immediately and the next tick tries again for free —
+ * no manual retry/cooldown babysitting needed.
+ */
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  const authorization = request.headers.get("authorization");
+  if (!cronSecret || authorization !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const deadline = Date.now() + TIME_BUDGET_MS;
+
+  const dmResult = await runDmConversationBackfillBatch(deadline).catch(() => {
+    console.error("Meta DM backfill batch failed", { errorCode: "dm_backfill_failed" });
+    return failedBatch("dm_backfill_failed");
+  });
+
+  const remainingBudget = deadline - Date.now();
+  const commentsResult =
+    remainingBudget > 5_000
+      ? await runIgCommentsBackfillBatch(deadline).catch(() => {
+          console.error("Meta comments backfill batch failed", {
+            errorCode: "comments_backfill_failed",
+          });
+          return failedBatch("comments_backfill_failed");
+        })
+      : { processed: 0, remaining: -1, stoppedReason: "deadline" as const };
+
+  return NextResponse.json({ dm: dmResult, comments: commentsResult });
+}

--- a/components/admin/DmLeadConversation.tsx
+++ b/components/admin/DmLeadConversation.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useOptimistic, useState, useTransition } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { DmMessageBubble } from "@/components/admin/DmMessageBubble";
+import { DmLeadReplyForm } from "@/components/admin/DmLeadReplyForm";
+import { replyToLead } from "@/app/admin/dm-leads/actions";
+import type { DmConversation, DmMessage } from "@/types/dm-leads";
+
+export function DmLeadConversation({ conversation }: { conversation: DmConversation }) {
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [optimisticMessages, addOptimisticMessage] = useOptimistic(
+    conversation.dm_messages,
+    (state, message: DmMessage) => [...state, message]
+  );
+
+  const handleSend = () => {
+    const text = body.trim();
+    if (!text) return;
+    setError(null);
+
+    const optimisticMessage: DmMessage = {
+      id: `optimistic-${Date.now()}`,
+      conversation_id: conversation.id,
+      direction: "outbound",
+      sender_type: "admin",
+      body: text,
+      platform_message_id: null,
+      message_type: "text",
+      metadata: {},
+      send_status: "pending",
+      delivered_at: null,
+      read_at: null,
+      sent_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+    };
+
+    setBody("");
+    startTransition(async () => {
+      addOptimisticMessage(optimisticMessage);
+      const result = await replyToLead(conversation.id, text);
+      if (!result.ok) {
+        setError(result.error);
+        setBody(text);
+      }
+    });
+  };
+
+  return (
+    <>
+      <Card>
+        <CardContent className="space-y-3 pt-6">
+          {optimisticMessages.map((message) => (
+            <DmMessageBubble key={message.id} message={message} />
+          ))}
+        </CardContent>
+      </Card>
+
+      <DmLeadReplyForm
+        conversation={conversation}
+        body={body}
+        onBodyChange={setBody}
+        onSend={handleSend}
+        isPending={isPending}
+        error={error}
+      />
+    </>
+  );
+}

--- a/components/admin/DmLeadDetailPane.tsx
+++ b/components/admin/DmLeadDetailPane.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { ChevronDown, ExternalLink, Flame, MessageSquareWarning } from "lucide-react";
+import { ChevronDown, ExternalLink } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { getThread, type LeadMetaPatch } from "@/app/admin/dm-leads/actions";
-import { summarizeLeadNeeds } from "@/lib/dm-leads/lead-summary";
 import {
   BUCKET_META,
   COVERAGE_OFFER,
@@ -21,7 +20,6 @@ import { DmLeadManageBar } from "@/components/admin/DmLeadManageBar";
 import { DM_REPLY_TEXTAREA_ID, DmLeadReplyForm } from "@/components/admin/DmLeadReplyForm";
 import { DmLeadScripts } from "@/components/admin/DmLeadScripts";
 import { DmLeadTagsEditor } from "@/components/admin/DmLeadTagsEditor";
-import { LeadNeedsSummary } from "@/components/admin/LeadNeedsSummary";
 import { LeadTagBadges } from "@/components/admin/LeadTagBadges";
 import { DmMessageBubble } from "@/components/admin/DmMessageBubble";
 import type { DmConversation, DmConversationWithMessages } from "@/types/dm-leads";
@@ -91,12 +89,14 @@ interface DmLeadDetailPaneProps {
   onSent: () => void;
   /** Syncs manage-bar patches (star, status, …) into the inbox list state. */
   onMetaChange?: (patch: LeadMetaPatch) => void;
+  /** Shared thread cache, lifted to the inbox so prefetched neighbors land here too. */
+  threadCache: React.RefObject<Map<string, DmConversationWithMessages>>;
 }
 
 /**
  * Right-hand reading pane of the DM inbox: lead header, needs summary,
- * full thread, and the reply box. Threads are cached per conversation so
- * keyboard navigation back and forth is instant.
+ * full thread, and the reply box. Threads are cached per conversation (and
+ * prefetched for neighboring leads by the inbox) so keyboard navigation is instant.
  */
 export function DmLeadDetailPane({
   conversation,
@@ -104,19 +104,15 @@ export function DmLeadDetailPane({
   onBodyChange,
   onSent,
   onMetaChange,
+  threadCache,
 }: DmLeadDetailPaneProps) {
   const [thread, setThread] = useState<DmConversationWithMessages | null>(null);
   const [loading, setLoading] = useState(true);
-  const [expanded, setExpanded] = useState(false);
   const [scriptsOpen, setScriptsOpen] = useState(false);
-  const cache = useRef(new Map<string, DmConversationWithMessages>());
   const threadRef = useRef<HTMLDivElement>(null);
 
-  // Fresh lead → collapse the details section again.
-  useEffect(() => setExpanded(false), [conversation.id]);
-
   useEffect(() => {
-    const cached = cache.current.get(conversation.id);
+    const cached = threadCache.current.get(conversation.id);
     if (cached) {
       setThread(cached);
       setLoading(false);
@@ -126,14 +122,14 @@ export function DmLeadDetailPane({
     setLoading(true);
     getThread(conversation.id).then((result) => {
       if (cancelled) return;
-      if (result) cache.current.set(conversation.id, result);
+      if (result) threadCache.current.set(conversation.id, result);
       setThread(result);
       setLoading(false);
     });
     return () => {
       cancelled = true;
     };
-  }, [conversation.id]);
+  }, [conversation.id, threadCache]);
 
   // Start scrolled to the newest message whenever the thread changes.
   useEffect(() => {
@@ -143,11 +139,9 @@ export function DmLeadDetailPane({
 
   const handleSent = () => {
     // The cached thread is now missing the sent message — drop it.
-    cache.current.delete(conversation.id);
+    threadCache.current.delete(conversation.id);
     onSent();
   };
-
-  const summary = summarizeLeadNeeds(conversation);
 
   // Signals need message history, which only exists here once the thread loads.
   // Until then the classifier runs on EMPTY_SIGNALS and settles on first paint.
@@ -198,36 +192,7 @@ export function DmLeadDetailPane({
             </span>
           )}
         </div>
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs transition-colors hover:bg-muted/60"
-          title="Needs summary & tags"
-        >
-          {summary.priority === "hot" && (
-            <Flame className="h-3 w-3 shrink-0 text-red-500" aria-label="Hot lead" />
-          )}
-          {summary.priority === "reply" && (
-            <MessageSquareWarning
-              className="h-3 w-3 shrink-0 text-amber-500"
-              aria-label="Awaiting our reply"
-            />
-          )}
-          <span className="shrink-0 font-medium">{summary.headline}</span>
-          <span className="truncate text-muted-foreground">→ {summary.suggestedAction}</span>
-          <ChevronDown
-            className={cn(
-              "ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
-              expanded && "rotate-180"
-            )}
-          />
-        </button>
-        {expanded && (
-          <div className="space-y-2 pb-1 pt-1">
-            <LeadNeedsSummary conversation={conversation} />
-            <DmLeadTagsEditor conversation={conversation} onChange={onMetaChange} />
-          </div>
-        )}
+        <DmLeadTagsEditor conversation={conversation} onChange={onMetaChange} />
       </div>
 
       <div className="shrink-0 border-b bg-muted/30 px-3 py-1.5">

--- a/components/admin/DmLeadReplyForm.tsx
+++ b/components/admin/DmLeadReplyForm.tsx
@@ -25,6 +25,12 @@ interface DmLeadReplyFormProps {
   onBodyChange?: (body: string) => void;
   /** Called after a reply is successfully sent. */
   onSent?: () => void;
+  /** When provided, overrides the built-in send handler (e.g. for optimistic UI). */
+  onSend?: () => void;
+  /** Externally controlled pending state — used together with onSend. */
+  isPending?: boolean;
+  /** Externally controlled error — used together with onSend. */
+  error?: string | null;
 }
 
 export function DmLeadReplyForm({
@@ -32,16 +38,21 @@ export function DmLeadReplyForm({
   body: controlledBody,
   onBodyChange,
   onSent,
+  onSend,
+  isPending: controlledIsPending,
+  error: controlledError,
 }: DmLeadReplyFormProps) {
   const [internalBody, setInternalBody] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, startTransition] = useTransition();
+  const [internalError, setInternalError] = useState<string | null>(null);
+  const [internalIsPending, startTransition] = useTransition();
 
   const body = controlledBody ?? internalBody;
   const setBody = (value: string) => {
     if (onBodyChange) onBodyChange(value);
     else setInternalBody(value);
   };
+  const error = onSend ? controlledError ?? null : internalError;
+  const isPending = onSend ? controlledIsPending ?? false : internalIsPending;
 
   const suggestions = useMemo(
     () => getQuickReplies(contextFromConversation(conversation)),
@@ -49,11 +60,15 @@ export function DmLeadReplyForm({
   );
 
   const handleSend = () => {
-    setError(null);
+    if (onSend) {
+      onSend();
+      return;
+    }
+    setInternalError(null);
     startTransition(async () => {
       const result = await replyToLead(conversation.id, body);
       if (!result.ok) {
-        setError(result.error);
+        setInternalError(result.error);
         return;
       }
       setBody("");

--- a/components/admin/DmLeadsInbox.tsx
+++ b/components/admin/DmLeadsInbox.tsx
@@ -6,7 +6,7 @@ import { Bell, Flame, Inbox, Keyboard, Maximize2, Minimize2, Star } from "lucide
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { contextFromConversation, getQuickReplies } from "@/lib/dm-leads/quick-replies";
-import { updateLead, type LeadMetaPatch } from "@/app/admin/dm-leads/actions";
+import { getThread, updateLead, type LeadMetaPatch } from "@/app/admin/dm-leads/actions";
 import { DmLeadDetailPane } from "@/components/admin/DmLeadDetailPane";
 import { DM_REPLY_TEXTAREA_ID } from "@/components/admin/DmLeadReplyForm";
 import { DM_LEAD_SEARCH_INPUT_ID } from "@/components/admin/DmLeadFilters";
@@ -14,7 +14,7 @@ import {
   followUpTomorrow,
   isFollowUpDue,
 } from "@/components/admin/DmLeadManageBar";
-import type { DmConversation, DmLeadStage } from "@/types/dm-leads";
+import type { DmConversation, DmConversationWithMessages, DmLeadStage } from "@/types/dm-leads";
 
 const STAGE_LABEL: Record<DmLeadStage, string> = {
   unknown: "Unknown",
@@ -80,6 +80,7 @@ export function DmLeadsInbox({ conversations }: { conversations: DmConversation[
   const [editorMode, setEditorMode] = useState<"normal" | "insert">("normal");
   const [fullscreen, setFullscreen] = useState(false);
   const pendingG = useRef(false);
+  const threadCache = useRef(new Map<string, DmConversationWithMessages>());
 
   // Persist the vim-mode preference across sessions. Loaded after mount to
   // avoid a server/client hydration mismatch.
@@ -114,6 +115,27 @@ export function DmLeadsInbox({ conversations }: { conversations: DmConversation[
 
   // Fresh reply box per conversation.
   useEffect(() => setReplyBody(""), [selected?.id]);
+
+  // Prefetch neighboring threads so j/k and send-then-advance feel instant
+  // instead of showing "Loading…" for ~2s on every new lead.
+  useEffect(() => {
+    const neighborIds = [
+      items[selectedIndex + 1]?.id,
+      items[selectedIndex - 1]?.id,
+    ].filter((id): id is string => Boolean(id) && !threadCache.current.has(id!));
+
+    if (neighborIds.length === 0) return;
+    let cancelled = false;
+    for (const id of neighborIds) {
+      getThread(id).then((result) => {
+        if (cancelled || !result) return;
+        threadCache.current.set(id, result);
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedIndex, items]);
 
   const suggestions = useMemo(
     () => (selected ? getQuickReplies(contextFromConversation(selected)) : []),
@@ -432,6 +454,7 @@ export function DmLeadsInbox({ conversations }: { conversations: DmConversation[
               onBodyChange={setReplyBody}
               onSent={handleSent}
               onMetaChange={syncMeta}
+              threadCache={threadCache}
             />
           )}
         </div>

--- a/lib/meta/backfill-runner.ts
+++ b/lib/meta/backfill-runner.ts
@@ -1,0 +1,139 @@
+import { listInstagramConversations, getConversationMessages, listInstagramMedia, getMediaComments } from "@/lib/meta/graph";
+import { recordBackfilledMessage, applyClassification } from "@/lib/supabase/dm-leads";
+import { upsertComment, applyCommentClassification } from "@/lib/supabase/ig-comments";
+import { classifyConversationText } from "@/lib/meta/classify";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+function isRateLimited(error: unknown): boolean {
+  return error instanceof Error && /"code":4\b/.test(error.message);
+}
+
+export interface BackfillBatchResult {
+  processed: number;
+  remaining: number;
+  stoppedReason: "deadline" | "rate_limited" | "done";
+}
+
+/**
+ * Processes DM conversations not yet in our DB, stopping at `deadlineMs` or
+ * on the first rate-limit hit. Stateless across invocations — "already done"
+ * is derived straight from dm_conversations, not a local checkpoint file, so
+ * a cron running this every N minutes just naturally resumes where the last
+ * run left off (and rides out Meta's rate limit between ticks for free).
+ */
+export async function runDmConversationBackfillBatch(deadlineMs: number): Promise<BackfillBatchResult> {
+  const igUserId = process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID;
+  if (!igUserId) throw new Error("Missing INSTAGRAM_BUSINESS_ACCOUNT_ID env var");
+
+  const supabase = createAdminClient();
+  const conversations = await listInstagramConversations(igUserId);
+
+  const { data: existing } = await supabase
+    .from("dm_conversations")
+    .select("platform_user_id")
+    .eq("platform", "instagram");
+  const doneParticipantIds = new Set((existing ?? []).map((r) => r.platform_user_id));
+
+  const pending = conversations.filter((convo) => {
+    const participant = convo.participants?.data.find((p) => p.id !== igUserId);
+    return participant && !doneParticipantIds.has(participant.id);
+  });
+
+  let processed = 0;
+  for (const convo of pending) {
+    if (Date.now() >= deadlineMs) {
+      return { processed, remaining: pending.length - processed, stoppedReason: "deadline" };
+    }
+
+    const participant = convo.participants!.data.find((p) => p.id !== igUserId)!;
+
+    try {
+      const messages = await getConversationMessages(convo.id);
+
+      let conversationId: string | null = null;
+      const inboundBodies: string[] = [];
+      for (const msg of messages) {
+        if (!msg.message) continue;
+
+        const direction = msg.from?.id === igUserId ? "outbound" : "inbound";
+        conversationId = await recordBackfilledMessage({
+          platform: "instagram",
+          platformThreadId: participant.id,
+          platformUserId: participant.id,
+          username: participant.username ?? null,
+          direction,
+          body: msg.message,
+          platformMessageId: msg.id,
+          sentAt: msg.created_time,
+        });
+        if (direction === "inbound") inboundBodies.push(msg.message);
+      }
+
+      if (conversationId && inboundBodies.length > 0) {
+        const classification = classifyConversationText(inboundBodies);
+        await applyClassification(conversationId, classification);
+      }
+
+      processed += 1;
+    } catch (error) {
+      if (isRateLimited(error)) {
+        return { processed, remaining: pending.length - processed, stoppedReason: "rate_limited" };
+      }
+      console.error("DM backfill skipped one conversation", {
+        errorCode: "conversation_backfill_failed",
+      });
+    }
+  }
+
+  return { processed, remaining: 0, stoppedReason: "done" };
+}
+
+/** Same idea as runDmConversationBackfillBatch, for post comments instead of DMs. */
+export async function runIgCommentsBackfillBatch(deadlineMs: number): Promise<BackfillBatchResult> {
+  const igUserId = process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID;
+  if (!igUserId) throw new Error("Missing INSTAGRAM_BUSINESS_ACCOUNT_ID env var");
+
+  const media = await listInstagramMedia(igUserId);
+
+  let processed = 0;
+  for (const item of media) {
+    if (Date.now() >= deadlineMs) {
+      return { processed, remaining: media.length - processed, stoppedReason: "deadline" };
+    }
+
+    try {
+      const comments = await getMediaComments(item.id);
+      for (const comment of comments) {
+        if (!comment.text) continue;
+
+        try {
+          const stored = await upsertComment({
+            igCommentId: comment.id,
+            mediaId: item.id,
+            parentCommentId: comment.parent_id ?? null,
+            username: comment.from?.username ?? comment.username ?? null,
+            igUserId: comment.from?.id ?? null,
+            text: comment.text,
+            commentedAt: comment.timestamp,
+          });
+          const classification = classifyConversationText([stored.text]);
+          await applyCommentClassification(stored.id, classification);
+        } catch (_error) {
+          console.error("Comments backfill skipped one comment", {
+            errorCode: "comment_backfill_failed",
+          });
+        }
+      }
+      processed += 1;
+    } catch (error) {
+      if (isRateLimited(error)) {
+        return { processed, remaining: media.length - processed, stoppedReason: "rate_limited" };
+      }
+      console.error("Comments backfill skipped one media item", {
+        errorCode: "media_comments_backfill_failed",
+      });
+    }
+  }
+
+  return { processed, remaining: 0, stoppedReason: "done" };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,9 @@
     "app/api/cron/parent-pathlab-updates/route.ts": {
       "maxDuration": 60
     },
+    "app/api/cron/meta-backfill/route.ts": {
+      "maxDuration": 60
+    },
     "app/api/**/*.ts": {
       "maxDuration": 10
     }
@@ -22,6 +25,10 @@
     {
       "path": "/api/cron/parent-pathlab-updates",
       "schedule": "0 2 * * *"
+    },
+    {
+      "path": "/api/cron/meta-backfill",
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What changed

- add a protected Vercel cron route that incrementally backfills Instagram DM conversations and comments
- resume naturally from persisted conversation state and stop cleanly at the execution deadline or Meta rate limit
- keep backfill logs and error responses free of user IDs, message bodies, and provider response details
- add optimistic sending to the full DM conversation page
- share and prefetch conversation threads in the inbox for faster keyboard navigation
- revalidate both the inbox and selected conversation after a reply

## Why

Webhooks cover new events, but they cannot recover conversations or comments that arrived before subscriptions were active or during delivery gaps. The scheduled catch-up closes that gap. The UI changes remove avoidable loading and send latency from the admin lead workflow.

## Checks

- targeted ESLint: pass
- targeted TypeScript error scan: pass
- 18 DM quick-reply, webhook route, and parser tests: pass
- `git diff --check`: pass

## Deployment note

The cron requires `CRON_SECRET`, `INSTAGRAM_BUSINESS_ACCOUNT_ID`, and the existing Meta access-token configuration in the deployment environment.
